### PR TITLE
Dwellir updates

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -10,7 +10,7 @@ rpcs[wss://polkadot-assethub-rpc.blockops.network/ws]="polkadot-assethub,eu-cent
 rpcs[wss://polkadot-rpc.dwellir.com]="polkadot,eu-central"
 rpcs[wss://asset-hub-polkadot-rpc.dwellir.com]="polkadot-assethub,eu-central"
 rpcs[wss://bridge-hub-polkadot-rpc.dwellir.com]="polkadot-bridgehub,eu-central"
-rpcs[wss://collectives-polkadot-rpc.dwellir.com]="polkadot-collectives,eu-central"
+rpcs[wss://collectives-polkadot-rpc.n.dwellir.com]="polkadot-collectives,eu-central"
 # Helixstreet dot
 rpcs[wss://rpc-polkadot.helixstreet.io]="polkadot,eu-central"
 # Luckyfriday dot
@@ -30,7 +30,7 @@ rpcs[wss://dot-rpc.stakeworld.io/coretime]="polkadot-coretime,eu-central"
 rpcs[wss://dot-rpc.stakeworld.io/people]="polkadot-people,eu-central"
 # Dwellir ksm-bridge + ksm-encointer 
 rpcs[wss://bridge-hub-kusama-rpc.dwellir.com]="kusama-bridgehub,eu-central"
-rpcs[wss://encointer-kusama-rpc.dwellir.com]="kusama-encointer,eu-central"
+rpcs[wss://encointer-kusama-rpc.n.dwellir.com]="kusama-encointer,eu-central"
 # Helixstreet ksm
 rpcs[wss://rpc-kusama.helixstreet.io]="kusama,eu-central"
 # Luckyfriday ksm

--- a/config.sh
+++ b/config.sh
@@ -46,4 +46,8 @@ rpcs[wss://ksm-rpc.stakeworld.io/assethub]="kusama-assethub,eu-central"
 rpcs[wss://ksm-rpc.stakeworld.io/bridgehub]="kusama-bridgehub,eu-central"
 # Dwellir westend
 rpcs[wss://westend-rpc.dwellir.com]="westend,eu-central"
-
+# Dwellir ksm-cor + ksm-peo + dot-cor + dot-peo
+rpcs[wss://coretime-kusama-rpc.n.dwellir.com]="kusama-coretime,eu-central"
+rpcs[wss://people-kusama-rpc.n.dwellir.com]="kusama-people,eu-central"
+rpcs[wss://coretime-polkadot-rpc.n.dwellir.com]="polkadot-coretime,eu-central"
+rpcs[wss://people-polkadot-rpc.n.dwellir.com]="polkadot-people,eu-central"


### PR DESCRIPTION
* New chains: Coretime and People for Polkadot and Kusama
* Updated some addresses to use a new sub-domain. Eventually all our endpoints will be migrated to this.