### PR TITLE
Add LinkPool Polkadot RPC endpoint

### DIFF
--- a/monitor.toml
+++ b/monitor.toml
@@ -191,3 +191,9 @@ url = "wss://ksm-rpc.stakeworld.io"
 network = "kusama"
 zone = "eu-central"
 provider = "stakeworld"
+
+[[endpoints]]
+url = "wss://polkadot-mainnet.linkpool.com"
+network = "polkadot"
+zone = "eu-central"
+provider = "LinkPool"


### PR DESCRIPTION
Adds LinkPool's public Polkadot relay WSS endpoint to monitor.toml:

| network  | url                                 |
|----------|-------------------------------------|
| polkadot | wss://polkadot-mainnet.linkpool.com |
