### PR TITLE
Add Rotko Networks endpoints (Polkadot/Kusama system chains)

### DIFF
--- a/monitor.toml
+++ b/monitor.toml
@@ -40,6 +40,7 @@ kusama-assethub = "0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2ed
 kusama-bridgehub = "0x00dcb981df86429de8bbacf9803401f09485366c44efbf53af9ecfab03adc7e5"
 kusama-encointer = "0x7dd99936c1e9e6d1ce7d90eb6f33bea8393b4bf87677d675aa63c9cb3e8c5b5b"
 kusama-coretime = "0x638cd2b9af4b3bb54b8c1f0d22711fc89924ca93300f0caf25a580432b29d050"
+kusama-people = "0xc1af4cb4eb3918e5db15086c0cc5ec17fb334f728b7c65dd44bfe1e174ff8b3f"
 westend = "0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e"
 
 [[endpoints]]
@@ -119,3 +120,57 @@ url = "wss://polkadot-mainnet.linkpool.com"
 network = "polkadot"
 zone = "eu-central"
 provider = "LinkPool"
+
+[[endpoints]]
+url = "wss://bridge-hub-polkadot.rotko.net"
+network = "polkadot-bridgehub"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://collectives-polkadot.rotko.net"
+network = "polkadot-collectives"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://coretime-polkadot.rotko.net"
+network = "polkadot-coretime"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://people-polkadot.rotko.net"
+network = "polkadot-people"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://asset-hub-kusama.rotko.net"
+network = "kusama-assethub"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://bridge-hub-kusama.rotko.net"
+network = "kusama-bridgehub"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://coretime-kusama.rotko.net"
+network = "kusama-coretime"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://encointer-kusama.rotko.net"
+network = "kusama-encointer"
+zone = "ap-southeast"
+provider = "Rotko"
+
+[[endpoints]]
+url = "wss://people-kusama.rotko.net"
+network = "kusama-people"
+zone = "ap-southeast"
+provider = "Rotko"


### PR DESCRIPTION
Adds Rotko Networks (provider `Rotko`) endpoints for the 9 Polkadot/Kusama system chains we serve:

**Polkadot:** BridgeHub, Collectives, Coretime, People
**Kusama:** Asset Hub, BridgeHub, Coretime, Encointer, People

Monitored from the `ap-southeast` (Singapore) zone, closest to our Bangkok PoP.

Also adds the `kusama-people` genesis hash to `[zero_hashes]` (it had a `network_to_chain` mapping but no genesis entry).

All endpoints are live over native IPv4/IPv6 at `wss://<chain>.rotko.net`.