### PR TITLE
Add Gatotech's endpoints

### DIFF
--- a/monitor.toml
+++ b/monitor.toml
@@ -180,3 +180,27 @@ url = "wss://people-kusama.rotko.net"
 network = "kusama-people"
 zone = "ap-southeast"
 provider = "Rotko"
+
+[[endpoints]]
+url = "wss://polkadot.gatotech.network"
+network = "polkadot"
+zone = "eu-central"
+provider = "Gatotech"
+
+[[endpoints]]
+url = "wss://kusama.gatotech.network"
+network = "kusama"
+zone = "eu-central"
+provider = "Gatotech"
+
+[[endpoints]]
+url = "wss://asset-hub-polkadot.gatotech.network"
+network = "polkadot-assethub"
+zone = "eu-central"
+provider = "Gatotech"
+
+# [[endpoints]]
+# url = "wss://eth-asset-hub-polkadot.gatotech.network"
+# network = "polkadot-assethub-eth"
+# zone = "eu-central"
+# provider = "Gatotech"


### PR DESCRIPTION
Dear team, hi again!

Please kindly consider this PR to add the RPC endpoints provided by Gatotech to the monitoring app of the RPC providers.

Please note that the information regarding the `eth-rpc` endpoint corresponding to the `asset-hub-polkadot` node is also added but commented away because I did not know if this is required and /or if this extra endpoint would break the report.. please advise!.

Many thanks!

**_Milos_**